### PR TITLE
Add current page actions

### DIFF
--- a/app/popup/js/components/view/header.js
+++ b/app/popup/js/components/view/header.js
@@ -1,10 +1,14 @@
-import React, {Component} from 'react'
+import React, {Component, PropTypes} from 'react'
 import Radium from 'radium'
 
 import IPFSLogo from './ipfs-logo'
 
 @Radium
 export default class Header extends Component {
+  static propTypes = {
+    style: PropTypes.object
+  };
+
   render () {
     const styles = {
       wrapper: {
@@ -15,18 +19,11 @@ export default class Header extends Component {
         alignSelf: 'center',
         flex: '1',
         paddingTop: '4px'
-      },
-      stopButton: {
-        background: 'none',
-        border: 'none',
-        position: 'absolute',
-        top: '11px',
-        right: '0'
       }
     }
 
     return (
-      <div style={styles.wrapper}>
+      <div style={[styles.wrapper, this.props.style]}>
         <div style={styles.text}>
           <IPFSLogo />
         </div>

--- a/app/popup/js/components/view/icon-button.js
+++ b/app/popup/js/components/view/icon-button.js
@@ -23,7 +23,7 @@ export default class IconButton extends Component {
   render () {
     const styles = {
       button: {
-        color: 'rgba(255, 255, 255, 0.8)',
+        opacity: 0.8,
         background: 'none',
         border: 'none',
         flex: '1',
@@ -36,7 +36,7 @@ export default class IconButton extends Component {
           outline: 'none'
         },
         ':hover': {
-          color: 'rgba(255, 255, 255, 1)',
+          opacity: 1,
           cursor: 'pointer'
         },
         ...this.props.style

--- a/app/popup/js/screens/menu/profile.js
+++ b/app/popup/js/screens/menu/profile.js
@@ -24,9 +24,12 @@ export default class ProfileScreen extends Component {
     protocolVersion: PropTypes.string,
     host: PropTypes.string,
     port: PropTypes.string,
+    isIpfsPage: PropTypes.bool,
+    pageUrl: PropTypes.string,
     onRedirectClick: PropTypes.func,
     onWebUIClick: PropTypes.func,
-    onOptionsClick: PropTypes.func
+    onOptionsClick: PropTypes.func,
+    onCopyToClipboard: PropTypes.func
   };
 
   static defaultProps = {
@@ -34,7 +37,8 @@ export default class ProfileScreen extends Component {
     location: '',
     onRedirectClick () {},
     onWebUIClick () {},
-    onOptionsClick () {}
+    onOptionsClick () {},
+    onCopyToClipboard () {}
   };
 
   render () {
@@ -43,22 +47,26 @@ export default class ProfileScreen extends Component {
         display: 'flex',
         width: '100%',
         height: '100%',
-        backgroundColor: '#19b5fe',
+        backgroundImage: `url(${require('../../../img/stars.png')})`,
+        backgroundSize: 'cover',
+        backgroundPosition: '0 10%',
         color: '#FFFFFF',
         flexDirection: 'column',
         alignItems: 'center'
       },
-      image: {
+      header: {
+        height: this.props.location ? '40px' : '60px'
+      },
+      location: {
         display: 'flex',
         flex: '1',
         color: '#FFFFFF',
-        backgroundImage: `url(${require('../../../img/stars.png')})`,
-        backgroundSize: 'cover',
-        backgroundPosition: '0 0',
         width: '100%',
+        minHeight: '30px',
         alignItems: 'center',
         justifyContent: 'center',
-        flexDirection: 'column'
+        flexDirection: 'column',
+        padding: '10px 0'
       },
       stats: {
         padding: '20px',
@@ -70,23 +78,67 @@ export default class ProfileScreen extends Component {
         height: '30%',
         justifyContent: 'space-around'
       },
-      footer: {
+      actions: {
         display: 'flex',
         height: '70px',
         justifyContent: 'space-around',
+        backgroundColor: '#19b5fe',
         width: '100%'
+      },
+      pageActions: {
+        wrapper: {
+          width: '100%',
+          backgroundImage: `url(${require('../../../img/stars.png')})`,
+          backgroundSize: 'cover',
+          backgroundPosition: '0 90%'
+        },
+        header: {
+          textAlign: 'center',
+          fontSize: '16px',
+          padding: '10px'
+        },
+        buttons: {
+          display: 'flex',
+          height: '70px',
+          justifyContent: 'space-around',
+          width: '100%'
+        }
       }
     }
 
+    const pageActions = this.props.isIpfsPage ? (
+      <div style={styles.pageActions.wrapper}>
+        <div style={styles.pageActions.header}>
+          Current address actions
+        </div>
+        <div style={styles.pageActions.buttons}>
+          <IconButton
+            name='Copy public url'
+            icon='forward'
+            onClick={this.props.onCopyToClipboard.bind(null, 'public-address')}
+            />
+          <IconButton
+            name='Copy canonical address'
+            icon='forward'
+            onClick={this.props.onCopyToClipboard.bind(null, 'address')}
+            />
+        </div>
+      </div>
+    ) : null
+
+    const location = this.props.location ? (
+      <div style={styles.location}>
+        <Icon name='location' style={{fontSize: '32px'}}/>
+        <div style={{margin: '0 auto'}}>
+          {this.props.location}
+        </div>
+      </div>
+    ) : null
+
     return (
       <div style={styles.wrapper}>
-        <Header />
-        <div style={styles.image}>
-          <Icon name='location' style={{padding: '10px 0', fontSize: '32px'}}/>
-          <div style={{margin: '0 auto'}}>
-            {this.props.location}
-          </div>
-        </div>
+        <Header style={styles.header}/>
+        {location}
         <div style={styles.stats}>
           <Details
             agentVersion={this.props.agentVersion}
@@ -100,7 +152,7 @@ export default class ProfileScreen extends Component {
             color='#50d2c2'
           />
         </div>
-        <div style={styles.footer}>
+        <div style={styles.actions}>
           <IconButton
             name='Options'
             icon='gear'
@@ -117,6 +169,7 @@ export default class ProfileScreen extends Component {
             onClick={this.props.onRedirectClick}
             />
         </div>
+        {pageActions}
       </div>
     )
   }

--- a/app/popup/js/screens/menu/profile.js
+++ b/app/popup/js/screens/menu/profile.js
@@ -26,10 +26,12 @@ export default class ProfileScreen extends Component {
     port: PropTypes.string,
     isIpfsPage: PropTypes.bool,
     pageUrl: PropTypes.string,
+    pinned: PropTypes.bool,
     onRedirectClick: PropTypes.func,
     onWebUIClick: PropTypes.func,
     onOptionsClick: PropTypes.func,
-    onCopyToClipboard: PropTypes.func
+    onCopyToClipboard: PropTypes.func,
+    onPinClick: PropTypes.func
   };
 
   static defaultProps = {
@@ -38,7 +40,8 @@ export default class ProfileScreen extends Component {
     onRedirectClick () {},
     onWebUIClick () {},
     onOptionsClick () {},
-    onCopyToClipboard () {}
+    onCopyToClipboard () {},
+    onPinClick () {}
   };
 
   render () {
@@ -121,6 +124,11 @@ export default class ProfileScreen extends Component {
             name='Copy canonical address'
             icon='forward'
             onClick={this.props.onCopyToClipboard.bind(null, 'address')}
+            />
+          <IconButton
+            name={this.props.pinned ? 'Unpin resource' : 'Pin resource'}
+            icon={this.props.pinned ? 'cross' : 'star'}
+            onClick={this.props.onPinClick}
             />
         </div>
       </div>

--- a/chrome/app/background/api.js
+++ b/chrome/app/background/api.js
@@ -1,5 +1,6 @@
 /* global chrome  */
 import ipfsAPI from 'ipfs-api'
+import { get } from 'lodash'
 
 const settingsKeys = ['host', 'apiPort', 'apiInterval']
 let settings = {}
@@ -59,6 +60,23 @@ chrome.storage.onChanged.addListener(function (changes, namespace) {
 
   if (needsRestart) {
     connectToAPI()
+  }
+})
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.method) {
+    const method = get(ipfs, request.method)
+    const args = request.args || []
+
+    args.push(function () {
+      console.log(request.method, 'result', arguments)
+      sendResponse(arguments)
+    })
+
+    console.log('executing', request.method)
+    method.apply(null, args)
+
+    return true
   }
 })
 

--- a/chrome/views/options.jade
+++ b/chrome/views/options.jade
@@ -5,7 +5,7 @@ html
     meta(charset='UTF-8')
     title IPFS Station Options  
     style.
-      body { width: 500px; min-height: 220px }
+      body { width: 400px; min-height: 220px }
   body
     #root
     script(src=env == 'prod' ? '/options.bundle.js' : 'http://localhost:3000/js/options.bundle.js')

--- a/chrome/views/popup.jade
+++ b/chrome/views/popup.jade
@@ -5,7 +5,7 @@ html
     meta(charset='UTF-8')
     title IPFS Station
     style.
-      body { width: 500px; min-height: 280px }
+      body { width: 450px; min-height: 250px; background-color: #19b5fe; }
   
   body
     #root

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "json-loader": "^0.5.3",
     "less": "^2.5.3",
     "less-loader": "^2.2.1",
+    "lodash": "^4.2.0",
     "normalize.css": "^3.0.3",
     "radium": "^0.15.3",
     "react": "^0.14.2",


### PR DESCRIPTION
Add IPFS loaded pages options like [ipfs-firefox-addon](https://github.com/lidel/ipfs-firefox-addon/)'s ones:
 - Pin IPFS Resource
 - Copy canonical IPFS address
 - Copy shareable URL to resource at a default public gateway

Required for #2 and closes #5

<img width="491" alt="screen shot 2016-02-02 at 17 54 43" src="https://cloud.githubusercontent.com/assets/1211330/12758828/154fa47e-c9d6-11e5-9a42-91b18769af3f.png">
